### PR TITLE
Update Wikipedia link and other tweaks

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
 	"name": "noop-process",
 	"version": "4.0.0",
-	"description": "Create a noop process and get the PID",
+	"description": "Create a noop (no operation) process and get the PID",
 	"license": "MIT",
 	"repository": "sindresorhus/noop-process",
 	"author": {
 		"name": "Sindre Sorhus",
 		"email": "sindresorhus@gmail.com",
-		"url": "sindresorhus.com"
+		"url": "https://sindresorhus.com"
 	},
 	"engines": {
 		"node": ">=8"

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # noop-process [![Build Status](https://travis-ci.org/sindresorhus/noop-process.svg?branch=master)](https://travis-ci.org/sindresorhus/noop-process)
 
-> Create a noop process and get the PID
+> Create a noop (no operation) process and get the PID
 
 Useful for testing purposes.
 
@@ -30,7 +30,7 @@ const noopProcess = require('noop-process');
 
 ### noopProcess(options?)
 
-Creates a [noop](https://en.wikipedia.org/wiki/NOP) process.
+Creates a [noop](https://en.wikipedia.org/wiki/NOP_(code)) process.
 
 Returns a `Promise<number>` with the process ID of the created process.
 


### PR DESCRIPTION
Updates the current outdated [Wikipedia link](https://en.wikipedia.org/wiki/NOP) to this new [NOP page](https://en.wikipedia.org/wiki/NOP_(code)). 
Also, adds the full form for the `noop` as  `noop (no operation)`.

// @sindresorhus 